### PR TITLE
Remove use of NotificationCenter

### DIFF
--- a/Shared/Scene/Animations.swift
+++ b/Shared/Scene/Animations.swift
@@ -37,13 +37,13 @@ class Animation {
         animationType = animation
     }
     
-    public func actions(clocks: [ClockNode], clusters: [ClusterNode], completionHandler: @escaping () -> Void) -> SKAction {
+    public func actions(clocks: [ClockNode], clusters: [ClusterNode], completionHandler: @escaping () -> Void, timeSetCompletionHandler: @escaping (String) -> Void) -> SKAction {
         
         switch animationType {
         case .spinBothHands:
             return spinBothHands(clocks: clocks, completionHandler: completionHandler)
         case .currentTimePrint:
-            return currentTimePrint(clusters: clusters, completionHandler: completionHandler)
+            return currentTimePrint(clusters: clusters, completionHandler: completionHandler, timeSetCompletionHandler: timeSetCompletionHandler)
         case .currentTimeClock:
             return currentTimeClock(clocks: clocks, completionHandler: completionHandler)
         case .wait:
@@ -152,7 +152,7 @@ class Animation {
         return SKAction.group(actions)
     }
     
-    private func currentTimePrint(clusters: [ClusterNode], completionHandler: @escaping () -> Void) -> SKAction {
+    private func currentTimePrint(clusters: [ClusterNode], completionHandler: @escaping () -> Void, timeSetCompletionHandler: @escaping (String) -> Void) -> SKAction {
         let date = Date()
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "hhmm"
@@ -176,7 +176,7 @@ class Animation {
             
         }
         
-        NotificationCenter.default.post(name: NSNotification.Name("SetCurrentTime"), object: nil, userInfo: ["time": timeString])
+        timeSetCompletionHandler(timeString)
         
         return SKAction.group(actions)
     }

--- a/Shared/Scene/Animations.swift
+++ b/Shared/Scene/Animations.swift
@@ -60,6 +60,54 @@ class Animation {
         
     }
     
+    // Static methods for queuing animations
+    
+    static func spinBothHands(by degrees: CGFloat) -> Animation {
+        let animation = Animation(animation: .spinBothHands)
+        animation.degrees = degrees
+        return animation
+    }
+    
+    static func printString(string: String) -> Animation {
+        let animation = Animation(animation: .print)
+        animation.string = string
+        return animation
+    }
+    
+    static func currentTimePrint() -> Animation {
+        return Animation(animation: .currentTimePrint)
+    }
+    
+    static func currentTimeClock() -> Animation {
+        return Animation(animation: .currentTimeClock)
+    }
+    
+    static func wait(duration: TimeInterval) -> Animation {
+        let animation = Animation(animation: .wait)
+        animation.duration = duration
+        return animation
+    }
+    
+    static func positionBothHands(minuteDegrees: CGFloat, hourDegrees: CGFloat) -> Animation {
+        let animation = Animation(animation: .positionBothHands)
+        animation.minuteDegrees = minuteDegrees
+        animation.hourDegrees = hourDegrees
+        return animation
+    }
+    
+    static func spinBothHandsWithDelay(by degrees: CGFloat, delay: TimeInterval) -> Animation {
+        let animation = Animation(animation: .spinBothHandsWithDelay)
+        animation.degrees = degrees
+        animation.delay = delay
+        return animation
+    }
+    
+    static func display(pattern: [Int: [(CGFloat, CGFloat)]]) -> Animation {
+        let animation = Animation(animation: .displayPattern)
+        animation.pattern = pattern
+        return animation
+    }
+    
     // Animations
     
     private func wait(clocks: [ClockNode]) -> SKAction {
@@ -273,53 +321,7 @@ class Animation {
         return distanceInDegrees.degreesToRadians()
     }
     
-    // Static methods for queuing animations
-    
-    static func spinBothHands(by degrees: CGFloat) -> Animation {
-        let animation = Animation(animation: .spinBothHands)
-        animation.degrees = degrees
-        return animation
-    }
-    
-    static func printString(string: String) -> Animation {
-        let animation = Animation(animation: .print)
-        animation.string = string
-        return animation
-    }
-    
-    static func currentTimePrint() -> Animation {
-        return Animation(animation: .currentTimePrint)
-    }
-    
-    static func currentTimeClock() -> Animation {
-        return Animation(animation: .currentTimeClock)
-    }
-    
-    static func wait(duration: TimeInterval) -> Animation {
-        let animation = Animation(animation: .wait)
-        animation.duration = duration
-        return animation
-    }
-    
-    static func positionBothHands(minuteDegrees: CGFloat, hourDegrees: CGFloat) -> Animation {
-        let animation = Animation(animation: .positionBothHands)
-        animation.minuteDegrees = minuteDegrees
-        animation.hourDegrees = hourDegrees
-        return animation
-    }
-    
-    static func spinBothHandsWithDelay(by degrees: CGFloat, delay: TimeInterval) -> Animation {
-        let animation = Animation(animation: .spinBothHandsWithDelay)
-        animation.degrees = degrees
-        animation.delay = delay
-        return animation
-    }
-    
-    static func display(pattern: [Int: [(CGFloat, CGFloat)]]) -> Animation {
-        let animation = Animation(animation: .displayPattern)
-        animation.pattern = pattern
-        return animation
-    }
+    // Pattern Generators
     
     static func randomizedPattern() -> [Int: [(CGFloat, CGFloat)]] {
         return [

--- a/Shared/Scene/ClockController.swift
+++ b/Shared/Scene/ClockController.swift
@@ -52,8 +52,6 @@ class ClockController {
         Log.useEmoji = true
         
         updateInterval = TimeInterval(1)
-        
-        NotificationCenter.default.addObserver(self, selector: #selector(setCurrentTime(_:)), name: NSNotification.Name("SetCurrentTime"), object: nil)
     }
     
     public func start() {
@@ -68,15 +66,6 @@ class ClockController {
     }
     
     // MARK: - Timer
-    
-    @objc func setCurrentTime(_ notification: NSNotification) {
-        if let time = notification.userInfo?["time"] as? String {
-            if time != lastTimeDisplayed {
-                Log.debug("New displayed time: \(time)")
-                lastTimeDisplayed = time
-            }
-        }
-    }
     
     @objc func updateTime() {
         let date = Date()
@@ -218,7 +207,7 @@ class ClockController {
     
     // MARK: - Animations
     
-    @objc func animationCompleted() {
+    private func animationCompleted() {
         timeSinceLastAnimation = 0
         animationsCompleted += 1
         if animationsCompleted == 48 {
@@ -234,8 +223,16 @@ class ClockController {
         }
     }
     
+    
+    private func setCurrentTime(time: String) {
+        if time != lastTimeDisplayed {
+            Log.debug("New displayed time: \(time)")
+            lastTimeDisplayed = time
+        }
+    }
+    
     private func run(_ animation: Animation) {
-        let actionGroup = animation.actions(clocks: clocks, clusters: clusters, completionHandler: animationCompleted)
+        let actionGroup = animation.actions(clocks: clocks, clusters: clusters, completionHandler: animationCompleted, timeSetCompletionHandler: setCurrentTime)
         isAnimating = true
         timeSinceLastAnimation = 0
         scene?.run(actionGroup)

--- a/Shared/Scene/ClockController.swift
+++ b/Shared/Scene/ClockController.swift
@@ -53,8 +53,6 @@ class ClockController {
         
         updateInterval = TimeInterval(1)
         
-        NotificationCenter.default.addObserver(self, selector: #selector(animationCompleted), name: NSNotification.Name("AnimationComplete"), object: nil)
-        
         NotificationCenter.default.addObserver(self, selector: #selector(setCurrentTime(_:)), name: NSNotification.Name("SetCurrentTime"), object: nil)
     }
     
@@ -237,7 +235,7 @@ class ClockController {
     }
     
     private func run(_ animation: Animation) {
-        let actionGroup = animation.actions(clocks: clocks, clusters: clusters)
+        let actionGroup = animation.actions(clocks: clocks, clusters: clusters, completionHandler: animationCompleted)
         isAnimating = true
         timeSinceLastAnimation = 0
         scene?.run(actionGroup)


### PR DESCRIPTION
I had a theory that the freezing part of this issue https://github.com/amiantos/multiclock/issues/6 was because of my use of `NotificationCenter.default`, namely that when firing the 'animationComplete' messages, they were being received by both instances of the screensaver, which made things get wonky. I didn't do anything to prove this theory, beyond the work of this PR.

I removed any usage of `NotificationCenter` and replaced it instead with completion handlers. It seems like this fixed the issue with multiple instances of the screensaver as well as fixed a millisecond or two delay when progressing through the animation queue, which is a nice benefit. Overall much better to do it this way, though it did mean I had to add a bunch of `completionHandler` arguments to stuff in the `Animation` file...